### PR TITLE
Bug/tasklist on click

### DIFF
--- a/app/components/Cards/CardItem.jsx
+++ b/app/components/Cards/CardItem.jsx
@@ -209,7 +209,13 @@ class MdynaCard extends Component {
         ) : (
           ''
         )}
-        <div role="button" tabIndex={0} onClick={() => noteActions.editCard(card)}>
+        <div
+          role="button"
+          tabIndex={0}
+          onDoubleClick={(e) => {
+            noteActions.editCard(card);
+          }}
+        >
           <MarkdownText
             whiteMode={whiteMode}
             className="note-card-content"

--- a/app/components/Cards/CardItem.jsx
+++ b/app/components/Cards/CardItem.jsx
@@ -212,7 +212,7 @@ class MdynaCard extends Component {
         <div
           role="button"
           tabIndex={0}
-          onDoubleClick={(e) => {
+          onDoubleClick={() => {
             noteActions.editCard(card);
           }}
         >
@@ -221,6 +221,7 @@ class MdynaCard extends Component {
             className="note-card-content"
             minimized={minimize}
             color={color}
+            editCard={{ card, func: noteActions.editCard }}
             text={card.text}
           />
         </div>

--- a/app/components/Cards/CardItem.jsx
+++ b/app/components/Cards/CardItem.jsx
@@ -221,7 +221,10 @@ class MdynaCard extends Component {
             className="note-card-content"
             minimized={minimize}
             color={color}
-            editCard={{ card, func: noteActions.editCard }}
+            editCard={{
+              card,
+              saveFunc: this.props.saveCard,
+            }}
             text={card.text}
           />
         </div>
@@ -253,6 +256,7 @@ MdynaCard.propTypes = {
   snoozeCard: PropTypes.func,
   failCard: PropTypes.func,
   toggleCard: PropTypes.func,
+  saveCard: PropTypes.func,
   completeCard: PropTypes.func,
   hasCardBar: PropTypes.bool,
   whiteMode: PropTypes.bool,
@@ -272,6 +276,7 @@ MdynaCard.defaultProps = {
   removeCard: null,
   snoozeCard: null,
   failCard: null,
+  saveCard: null,
   completeCard: null,
   generateCardLink: null,
   editCard: null,

--- a/app/components/Cards/CardPreview.jsx
+++ b/app/components/Cards/CardPreview.jsx
@@ -4,8 +4,16 @@ import NoteItem from './CardItem';
 
 class cardPreview extends Component {
   render() {
-    const { card, changeCardSetting } = this.props;
-    return <NoteItem className="card-preview" changeCardSetting={changeCardSetting} card={card} showAllText />;
+    const { card, changeCardSetting, saveCard } = this.props;
+    return (
+      <NoteItem
+        className="card-preview"
+        changeCardSetting={changeCardSetting}
+        saveCard={saveCard}
+        card={card}
+        showAllText
+      />
+    );
   }
 }
 
@@ -14,6 +22,7 @@ export default cardPreview;
 cardPreview.propTypes = {
   card: PropTypes.object,
   changeCardSetting: PropTypes.func.isRequired,
+  saveCard: PropTypes.func.isRequired,
 };
 
 cardPreview.defaultProps = {

--- a/app/components/MarkdownText.jsx
+++ b/app/components/MarkdownText.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { Converter } from 'react-showdown';
 import htmlescape from 'showdown-htmlescape';
+import CheckBox from 'grommet/components/CheckBox';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import regExp from '../utils/regexp';
@@ -24,6 +25,17 @@ const COLOR_LABELS = {
 class MarkdownText extends Component {
   render() {
     const { text, className, color, minimized, whiteMode } = this.props;
+    /*
+    const input = () => (
+      <CheckBox
+        className="card-tasklist"
+        onClick={(e) => {
+          e.stopPropagation();
+          console.log(this, e.isPropagationStopped());
+        }}
+      />
+    );
+    */
     const converter = new Converter({
       headerLevelStart: 3,
       strikethrough: true,
@@ -36,6 +48,7 @@ class MarkdownText extends Component {
       literalMidWordUnderscores: true,
       openLinksInNewWindow: true,
       extensions: [htmlescape],
+      flavor: 'github',
     });
     let noteText = text && text.length > 300 ? `${text.substring(0, 300)}...` : text;
 
@@ -46,13 +59,24 @@ class MarkdownText extends Component {
     const rawText = minimized ? noteText : text;
     const formattedText = converter.convert(rawText) || '';
     return (
-      <ReactHighlight
-        element="div"
-        text={rawText}
-        className={classnames(className, COLOR_LABELS[color], whiteMode && 'white-mode', 'mdyna-md')}
-      >
-        {formattedText}
-      </ReactHighlight>
+      <React.Fragment>
+
+        <ReactHighlight
+          element="div"
+          text={rawText}
+          className={classnames(
+            className,
+            COLOR_LABELS[color],
+            whiteMode && 'white-mode',
+            'mdyna-md',
+          )}
+        >
+          {formattedText}
+        </ReactHighlight>
+        <div>
+          {formattedText}
+        </div>
+      </React.Fragment>
     );
   }
 }

--- a/app/components/MarkdownText.jsx
+++ b/app/components/MarkdownText.jsx
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
 import { Converter } from 'react-showdown';
 import htmlescape from 'showdown-htmlescape';
-import CheckBox from 'grommet/components/CheckBox';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import regExp from '../utils/regexp';
 import ReactHighlight from './CodeHighlight';
+import TaskListInput from './TaskListInput';
 
 import '!style-loader!css-loader!sass-loader!./MarkdownText.scss'; // eslint-disable-line
 
@@ -24,18 +24,10 @@ const COLOR_LABELS = {
 
 class MarkdownText extends Component {
   render() {
-    const { text, className, color, minimized, whiteMode } = this.props;
-    /*
-    const input = () => (
-      <CheckBox
-        className="card-tasklist"
-        onClick={(e) => {
-          e.stopPropagation();
-          console.log(this, e.isPropagationStopped());
-        }}
-      />
+    const { text, className, color, minimized, whiteMode, editCard } = this.props;
+    const input = (...otherProps) => (
+      <TaskListInput className="card-tasklist" text={text} editCard={editCard} {...otherProps} />
     );
-    */
     const converter = new Converter({
       headerLevelStart: 3,
       strikethrough: true,
@@ -49,6 +41,7 @@ class MarkdownText extends Component {
       openLinksInNewWindow: true,
       extensions: [htmlescape],
       flavor: 'github',
+      components: { input },
     });
     let noteText = text && text.length > 300 ? `${text.substring(0, 300)}...` : text;
 
@@ -60,7 +53,6 @@ class MarkdownText extends Component {
     const formattedText = converter.convert(rawText) || '';
     return (
       <React.Fragment>
-
         <ReactHighlight
           element="div"
           text={rawText}
@@ -73,9 +65,7 @@ class MarkdownText extends Component {
         >
           {formattedText}
         </ReactHighlight>
-        <div>
-          {formattedText}
-        </div>
+        <div>{formattedText}</div>
       </React.Fragment>
     );
   }

--- a/app/components/TaskListInput.jsx
+++ b/app/components/TaskListInput.jsx
@@ -1,0 +1,80 @@
+import React, { Component } from 'react';
+import htmlescape from 'showdown-htmlescape';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import regExp from '../utils/regexp';
+import ReactHighlight from './CodeHighlight';
+
+import '!style-loader!css-loader!sass-loader!./MarkdownText.scss'; // eslint-disable-line
+
+const COLOR_LABELS = {
+  '#ff8a80': 'red',
+  '#ff80ab': 'pink',
+  '#ea80fc': 'purple',
+  '#8c9eff': 'dark-blue',
+  '#80d8ff': 'light-blue',
+  '#a7ffeb': 'mdyna-green',
+  '#b9f6ca': 'green',
+  '#fff475': 'yellow',
+  '#ffd180': 'orange',
+  '#a7c0cd': 'grey',
+};
+
+class TaskListInput extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      checked: false,
+    };
+  }
+
+  render() {
+    const { text, editCard, otherProps } = this.props;
+    console.log(editCard, this.props);
+
+    return (
+      <input
+        className="card-tasklist"
+        type="checkbox"
+        defaultChecked
+        onClick={(e) => {
+          e.stopPropagation();
+          const { card, saveFunc } = editCard;
+          const inputTextContent = e.target.parentElement.textContent;
+          let newText = '';
+          if (e.target.checked) {
+            const inputText = `[ ]${inputTextContent}`;
+            newText = text.replace(inputText, `[X]${inputTextContent}`);
+          } else {
+            const inputText =
+              (text.indexOf(`[X]${inputTextContent}`) !== -1 && `[X]${inputTextContent}`) ||
+              (text.indexOf(`[x]${inputTextContent} `) !== -1 && `[x]${inputTextContent}`) ||
+              null;
+            newText = text.replace(inputText, `[ ] ${inputTextContent}`);
+          }
+          saveFunc({
+            ...card,
+            text: newText,
+          });
+        }}
+      />
+    );
+  }
+}
+
+export default TaskListInput;
+
+TaskListInput.propTypes = {
+  text: PropTypes.string,
+  className: PropTypes.string.isRequired,
+  minimized: PropTypes.bool,
+  whiteMode: PropTypes.bool,
+  color: PropTypes.string,
+};
+
+TaskListInput.defaultProps = {
+  minimized: false,
+  whiteMode: false,
+  color: '#4E636E',
+  text: '',
+};

--- a/app/components/TaskListInput.jsx
+++ b/app/components/TaskListInput.jsx
@@ -1,42 +1,22 @@
 import React, { Component } from 'react';
-import htmlescape from 'showdown-htmlescape';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
-import regExp from '../utils/regexp';
-import ReactHighlight from './CodeHighlight';
-
-import '!style-loader!css-loader!sass-loader!./MarkdownText.scss'; // eslint-disable-line
-
-const COLOR_LABELS = {
-  '#ff8a80': 'red',
-  '#ff80ab': 'pink',
-  '#ea80fc': 'purple',
-  '#8c9eff': 'dark-blue',
-  '#80d8ff': 'light-blue',
-  '#a7ffeb': 'mdyna-green',
-  '#b9f6ca': 'green',
-  '#fff475': 'yellow',
-  '#ffd180': 'orange',
-  '#a7c0cd': 'grey',
-};
 
 class TaskListInput extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      checked: false,
+      checked: this.props[0].defaultChecked,
     };
   }
 
   render() {
-    const { text, editCard, otherProps } = this.props;
-    console.log(editCard, this.props);
+    const { text, editCard, ...otherProps } = this.props;
 
     return (
       <input
         className="card-tasklist"
         type="checkbox"
-        defaultChecked
+        checked={this.props[0].defaultChecked}
         onClick={(e) => {
           e.stopPropagation();
           const { card, saveFunc } = editCard;
@@ -48,15 +28,17 @@ class TaskListInput extends Component {
           } else {
             const inputText =
               (text.indexOf(`[X]${inputTextContent}`) !== -1 && `[X]${inputTextContent}`) ||
-              (text.indexOf(`[x]${inputTextContent} `) !== -1 && `[x]${inputTextContent}`) ||
+              (text.indexOf(`[x]${inputTextContent}`) !== -1 && `[x]${inputTextContent}`) ||
               null;
             newText = text.replace(inputText, `[ ] ${inputTextContent}`);
           }
+
           saveFunc({
             ...card,
             text: newText,
           });
         }}
+        {...otherProps}
       />
     );
   }
@@ -66,15 +48,9 @@ export default TaskListInput;
 
 TaskListInput.propTypes = {
   text: PropTypes.string,
-  className: PropTypes.string.isRequired,
-  minimized: PropTypes.bool,
-  whiteMode: PropTypes.bool,
-  color: PropTypes.string,
+  editCard: PropTypes.object.isRequired,
 };
 
 TaskListInput.defaultProps = {
-  minimized: false,
-  whiteMode: false,
-  color: '#4E636E',
   text: '',
 };

--- a/app/containers/CardItem.js
+++ b/app/containers/CardItem.js
@@ -11,6 +11,7 @@ import {
   addLabel,
   removeLabel,
   changeCardSetting,
+  saveCard,
 } from '../store/actions/';
 
 function mapDispatchToProps(dispatch) {
@@ -29,6 +30,9 @@ function mapDispatchToProps(dispatch) {
     },
     changeCardSetting: (prop, value) => {
       dispatch(changeCardSetting(prop, value));
+    },
+    saveCard: (card) => {
+      dispatch(saveCard(card));
     },
     snoozeCard: (card) => {
       dispatch(snoozeCard(card));

--- a/app/containers/CardPreview.js
+++ b/app/containers/CardPreview.js
@@ -1,9 +1,20 @@
 import { connect } from 'react-redux';
 import cardPreview from '../components/Cards/CardPreview';
+import { saveCard } from '../store/actions/';
 
+function mapDispatchToProps(dispatch) {
+  return {
+    removeCard: (card) => {
+      dispatch(saveCard(card));
+    },
+  };
+}
 function mapStateToProps(state) {
   return {
     card: state.editor,
   };
 }
-export default connect(mapStateToProps)(cardPreview);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(cardPreview);

--- a/app/package.json
+++ b/app/package.json
@@ -28,7 +28,7 @@
     "react-hot-loader": "3.0.0-beta.6",
     "react-redux": "^5.0.6",
     "react-router-dom": "4.1.1",
-    "react-showdown": "^1.6.0",
+    "react-showdown": "https://github.com/psybork/react-showdown.git",
     "react-simplemde-editor": "^3.6.16",
     "redux": "^3.7.2",
     "redux-logger": "^3.0.6",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -684,7 +684,15 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-create-react-class@^15.5.1, create-react-class@^15.5.2:
+create-react-class@15.5.2:
+  version "15.5.2"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.5.2.tgz#6a8758348df660b88326a0e764d569f274aad681"
+  integrity sha1-aodYNI32YLiDJqDnZNVp8nSq1oE=
+  dependencies:
+    fbjs "^0.8.9"
+    object-assign "^4.1.1"
+
+create-react-class@^15.5.1:
   version "15.6.3"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
   integrity sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==
@@ -1136,17 +1144,16 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
   integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
 
-htmlparser2@^3.9.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.0.tgz#5f5e422dcf6119c0d983ed36260ce9ded0bee464"
-  integrity sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==
+htmlparser2@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.0.tgz#1bd6ba4d3358bbd31f93e13fb952961cf4d31b3f"
+  integrity sha1-G9a6TTNYu9Mfk+E/uVKWHPTTGz8=
   dependencies:
     domelementtype "^1.3.0"
     domhandler "^2.3.0"
     domutils "^1.5.1"
     entities "^1.1.1"
-    inherits "^2.0.1"
-    readable-stream "^3.0.6"
+    readable-stream "^2.0.2"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -1171,7 +1178,7 @@ indent-string@^2.1.0:
   dependencies:
     repeating "^2.0.0"
 
-inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
@@ -1776,6 +1783,13 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@15.5.8:
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  integrity sha1-a3suFBCDvjjIWVqlH8VXdccZk5Q=
+  dependencies:
+    fbjs "^0.8.9"
+
 prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
@@ -1941,15 +1955,14 @@ react-router@^3.0.0:
     prop-types "^15.5.6"
     warning "^3.0.0"
 
-react-showdown@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/react-showdown/-/react-showdown-1.6.0.tgz#01275752744a26a9dca83a9dd567079077251b51"
-  integrity sha1-ASdXUnRKJqncqDqd1WcHkHclG1E=
+"react-showdown@https://github.com/psybork/react-showdown.git":
+  version "1.8.1"
+  resolved "https://github.com/psybork/react-showdown.git#08a56fee9ff82eab0f43d24b2e01106fc528faa7"
   dependencies:
-    create-react-class "^15.5.2"
-    htmlparser2 "^3.9.0"
-    prop-types "^15.5.8"
-    showdown "^1.5.0"
+    create-react-class "15.5.2"
+    htmlparser2 "3.9.0"
+    prop-types "15.5.8"
+    showdown "^1.9.0"
 
 react-simplemde-editor@^3.6.16:
   version "3.6.22"
@@ -1998,7 +2011,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@^2.2.2, readable-stream@^2.3.5:
+readable-stream@^2.0.2, readable-stream@^2.2.2, readable-stream@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -2010,15 +2023,6 @@ readable-stream@^2.2.2, readable-stream@^2.3.5:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
-
-readable-stream@^3.0.6:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.1.1.tgz#ed6bbc6c5ba58b090039ff18ce670515795aeb06"
-  integrity sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
 
 readable-stream@~1.1.9:
   version "1.1.14"
@@ -2210,7 +2214,7 @@ showdown-htmlescape@^0.1.9:
   dependencies:
     showdown "^1.2.3"
 
-showdown@^1.2.3, showdown@^1.5.0:
+showdown@^1.2.3, showdown@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/showdown/-/showdown-1.9.0.tgz#d49d2a0b6db21b7c2e96ef855f7b3b2a28ef46f4"
   integrity sha512-x7xDCRIaOlicbC57nMhGfKamu+ghwsdVkHMttyn+DelwzuHOx4OHCVL/UW/2QOLH7BxfCcCCVVUix3boKXJKXQ==
@@ -2329,13 +2333,6 @@ string-width@^2.0.0, string-width@^2.1.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-string_decoder@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
-  integrity sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==
-  dependencies:
-    safe-buffer "~5.1.0"
 
 string_decoder@~0.10.x:
   version "0.10.31"
@@ -2500,7 +2497,7 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-util-deprecate@^1.0.1, util-deprecate@~1.0.1:
+util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=


### PR DESCRIPTION
Update react-showdown dependency  …
  - Forked react-showdown in order to support 'flavor' option
  - This fork also updates showdown (1.6 -> 1.9)

Pass card and edit action to MarkdownText component
Add TaskListInput component 
  - Pass save function from cardItem reducer and apply it from MarkdownText

Finish taskListInput component which will save card changes when toggling an input
- Should also work with cardPreview component
- Did the necessary adjustments to cardPreview container
- Close #97